### PR TITLE
Fix output file going to wrong directory

### DIFF
--- a/.mise/tasks/generate
+++ b/.mise/tasks/generate
@@ -11,6 +11,12 @@ PROMPT="${usage_prompt}"
 OUTPUT="${usage_output}"
 MODEL="${usage_model}"
 TOKEN="${usage_token:-$HF_TOKEN}"
+CALLER_DIR="${MONKEYS_CALLER_PWD:-$(pwd)}"
+
+# Resolve relative output paths to caller's directory
+if [[ "$OUTPUT" != /* ]]; then
+    OUTPUT="${CALLER_DIR}/${OUTPUT}"
+fi
 
 if [[ -z "$TOKEN" ]]; then
     echo "Error: No API token provided"

--- a/.mise/tasks/shell
+++ b/.mise/tasks/shell
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 #MISE description="Output shell configuration for global monkeys command (use with eval)"
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-echo "alias monkeys='SHIMMER_CALLER_PWD=\"\$PWD\" mise -C \"$REPO_DIR\" run'"
+echo "alias monkeys='MONKEYS_CALLER_PWD=\"\$PWD\" mise -C \"$REPO_DIR\" run'"


### PR DESCRIPTION
## Summary

- Output files now go to the directory from which `monkeys` was invoked
- Renamed `SHIMMER_CALLER_PWD` to `MONKEYS_CALLER_PWD` (monkeys is its own project)
- Relative output paths are resolved against the caller's directory

## Test plan

- [x] `cd /tmp && monkeys generate "test" -o test.png` creates `/tmp/test.png`
- [x] Absolute paths (`-o /some/path/img.png`) still work

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)