### PR TITLE
Add stdin/stdout piping for speak and listen

### DIFF
--- a/.mise/tasks/listen
+++ b/.mise/tasks/listen
@@ -30,8 +30,20 @@ if [[ "$RECORD" == "true" ]]; then
     mise run record "${RECORD_ARGS[@]}"
     FILE="$RECORD_FILE"
 elif [[ -z "$FILE" ]]; then
-    echo "Error: Provide an audio file or use --record" >&2
-    exit 1
+    if [[ -t 0 ]]; then
+        echo "Error: Provide an audio file, use --record, or pipe audio to stdin" >&2
+        exit 1
+    fi
+    # Read audio from stdin to temp file
+    STDIN_TMPDIR=$(mktemp -d /tmp/monkeys-stdin-XXXXXX)
+    STDIN_FILE="${STDIN_TMPDIR}/input.wav"
+    cat > "$STDIN_FILE"
+    if [[ ! -s "$STDIN_FILE" ]]; then
+        echo "Error: No audio data received from stdin" >&2
+        rm -rf "$STDIN_TMPDIR"
+        exit 1
+    fi
+    FILE="$STDIN_FILE"
 else
     # Resolve relative input path to caller's directory
     if [[ "$FILE" != /* ]]; then
@@ -64,7 +76,7 @@ mkdir -p "$MODEL_DIR"
 # Resample to 16kHz WAV (whisper requirement)
 LISTEN_TMPDIR=$(mktemp -d /tmp/monkeys-listen-XXXXXX)
 TMPFILE="${LISTEN_TMPDIR}/resampled.wav"
-trap 'rm -rf "$LISTEN_TMPDIR" "${RECORD_TMPDIR:-}"' EXIT
+trap 'rm -rf "$LISTEN_TMPDIR" "${RECORD_TMPDIR:-}" "${STDIN_TMPDIR:-}"' EXIT
 ffmpeg -i "$FILE" -ar 16000 -ac 1 -y "$TMPFILE" 2>/dev/null
 
 # Transcription cache

--- a/.mise/tasks/speak
+++ b/.mise/tasks/speak
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 #MISE description="Generate speech from text"
-#USAGE arg "<text>" help="Text to convert to speech"
+#USAGE arg "[text]" help="Text to convert to speech (reads from stdin if omitted)"
 #USAGE flag "-o --output <file>" help="Output file path" default="output.wav"
 #USAGE flag "--voice <voice>" help="Voice to use (e.g. af_heart, af_bella, am_adam)" default="af_heart"
 #USAGE flag "--speed <speed>" help="Speech speed multiplier" default="1.0"
 #USAGE flag "--play" help="Play audio after generating"
+#USAGE flag "--stdout" help="Write WAV audio to stdout instead of file"
 #USAGE flag "--no-cache" help="Skip cache (force regeneration)"
 #USAGE flag "--no-meta" help="Don't save metadata sidecar file"
 
@@ -15,15 +16,39 @@ OUTPUT="${usage_output}"
 VOICE="${usage_voice}"
 SPEED="${usage_speed}"
 PLAY="${usage_play:-false}"
+STDOUT="${usage_stdout:-false}"
 NO_CACHE="${usage_no_cache:-false}"
 NO_META="${usage_no_meta:-false}"
 CALLER_DIR="${MONKEYS_CALLER_PWD:-$(pwd)}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
+# Read text from stdin if no argument provided
+if [[ -z "$TEXT" ]]; then
+    if [[ -t 0 ]]; then
+        echo "Error: Provide text as an argument or pipe to stdin" >&2
+        exit 1
+    fi
+    trap '' INT   # Survive Ctrl+C from upstream (e.g. record stopping)
+    TEXT=$(cat)
+    trap - INT    # Restore default signal handling
+    if [[ -z "$TEXT" ]]; then
+        echo "Error: No text received from stdin" >&2
+        exit 1
+    fi
+fi
+
 # Resolve relative output paths to caller's directory
 if [[ "$OUTPUT" != /* ]]; then
     OUTPUT="${CALLER_DIR}/${OUTPUT}"
+fi
+
+# In stdout mode, write to temp file and skip metadata
+if [[ "$STDOUT" == "true" ]]; then
+    SPEAK_TMPDIR=$(mktemp -d /tmp/monkeys-speak-XXXXXX)
+    trap 'rm -rf "$SPEAK_TMPDIR"' EXIT
+    OUTPUT="${SPEAK_TMPDIR}/output.wav"
+    NO_META="true"
 fi
 
 # Model cache directory
@@ -34,20 +59,20 @@ RELEASE_URL="https://github.com/thewh1teagle/kokoro-onnx/releases/download/model
 
 # Download models on first run
 if [[ ! -f "$MODEL_FILE" || ! -f "$VOICES_FILE" ]]; then
-    echo "Downloading Kokoro model files (first run only)..."
+    echo "Downloading Kokoro model files (first run only)..." >&2
     mkdir -p "$MODEL_DIR"
 
     if [[ ! -f "$MODEL_FILE" ]]; then
-        echo "  Downloading kokoro-v1.0.onnx (~310 MB)..."
+        echo "  Downloading kokoro-v1.0.onnx (~310 MB)..." >&2
         curl -L -o "$MODEL_FILE" "${RELEASE_URL}/kokoro-v1.0.onnx"
     fi
 
     if [[ ! -f "$VOICES_FILE" ]]; then
-        echo "  Downloading voices-v1.0.bin..."
+        echo "  Downloading voices-v1.0.bin..." >&2
         curl -L -o "$VOICES_FILE" "${RELEASE_URL}/voices-v1.0.bin"
     fi
 
-    echo "  Done! Models cached at $MODEL_DIR"
+    echo "  Done! Models cached at $MODEL_DIR" >&2
 fi
 
 # Audio cache
@@ -58,13 +83,13 @@ CACHE_FILE="${AUDIO_CACHE_DIR}/${CACHE_KEY}.wav"
 # Check cache
 if [[ "$NO_CACHE" != "true" && -f "$CACHE_FILE" ]]; then
     cp "$CACHE_FILE" "$OUTPUT"
-    echo "Cache hit! Audio copied to $OUTPUT"
+    echo "Cache hit! Audio copied to $OUTPUT" >&2
 else
-    echo "Generating speech..."
-    echo "  Text: $TEXT"
-    echo "  Voice: $VOICE"
-    echo "  Speed: $SPEED"
-    echo "  Output: $OUTPUT"
+    echo "Generating speech..." >&2
+    echo "  Text: $TEXT" >&2
+    echo "  Voice: $VOICE" >&2
+    echo "  Speed: $SPEED" >&2
+    echo "  Output: $OUTPUT" >&2
 
     uv run "$REPO_DIR/scripts/speak.py" \
         --text "$TEXT" \
@@ -73,7 +98,7 @@ else
         --speed "$SPEED" \
         --model-dir "$MODEL_DIR"
 
-    echo "Done! Audio saved to $OUTPUT"
+    echo "Done! Audio saved to $OUTPUT" >&2
 
     # Store in cache
     if [[ "$NO_CACHE" != "true" ]]; then
@@ -98,10 +123,15 @@ if [[ "$NO_META" != "true" ]]; then
         --arg output "$(basename "$OUTPUT")" \
         '{text: $text, voice: $voice, speed: $speed, model: $model, timestamp: $timestamp, size_bytes: $size, output: $output}' \
         > "$META_FILE"
-    echo "  Metadata saved to $META_FILE"
+    echo "  Metadata saved to $META_FILE" >&2
 fi
 
 # Play audio if requested
 if [[ "$PLAY" == "true" ]]; then
     mise run play "$OUTPUT"
+fi
+
+# Write to stdout if requested
+if [[ "$STDOUT" == "true" ]]; then
+    cat "$OUTPUT"
 fi


### PR DESCRIPTION
## Summary

- `speak` reads text from stdin when no argument provided
- `speak --stdout` writes WAV audio to stdout instead of file
- `listen` accepts piped audio on stdin (no file arg, no `--record`)
- All `speak` informational output moved to stderr (unix convention, matching `listen`)

Enables unix-style pipelines:
```bash
echo "hello" | monkeys speak --stdout | monkeys listen
monkeys listen --record | monkeys speak --play
```

Closes #21

## Test plan

- [ ] `monkeys speak "hello" -o /tmp/test.wav` — still works as before
- [ ] `echo "hello" | monkeys speak -o /tmp/test.wav` — stdin text input
- [ ] `monkeys speak "hello" --stdout > /tmp/test.wav` — stdout audio output
- [ ] `echo "hello" | monkeys speak --stdout | monkeys listen` — full round-trip
- [ ] `monkeys listen --record | monkeys speak --play` — record → repeat
- [ ] `monkeys speak` (no args, no pipe) — errors with helpful message
- [ ] `monkeys listen` (no args, no pipe) — errors with helpful message

🤖 Generated with [Claude Code](https://claude.com/claude-code)