### PR TITLE
fix: use unique listen temp files

### DIFF
--- a/.mise/tasks/listen/_default
+++ b/.mise/tasks/listen/_default
@@ -109,8 +109,8 @@ if [ "$write_stdout" = "true" ]; then
 else
   output_dir="$(dirname "$OUTPUT")"
   output_base="$(basename "$OUTPUT")"
-  tmp_output="${output_dir}/.${output_base}.tmp.$$"
   mkdir -p "$output_dir"
+  tmp_output="$(mktemp "${output_dir}/.${output_base}.tmp.XXXXXX")"
   cleanup_tmp_output() {
     rm -f "$tmp_output"
   }


### PR DESCRIPTION
Fix-it for KnickKnackLabs/monkeys#36.

The listen output path now uses `mktemp` in the destination directory instead of a PID-derived filename. This preserves same-filesystem atomic replacement while avoiding stale hidden temp files from a killed prior run or PID reuse masking an ffmpeg failure.

Validation:
- `bash -n .mise/tasks/listen/_default`
- `mise run test listen_hear` (11/11)
- `git diff --check`
